### PR TITLE
Feature/backend/abm usuarios

### DIFF
--- a/backend/backend_spring/pom.xml
+++ b/backend/backend_spring/pom.xml
@@ -52,7 +52,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
@@ -87,6 +86,10 @@
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
 			<version>3.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/backend/backend_spring/src/main/java/com/inventoMate/configuration/GlobalErrorHandler.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/configuration/GlobalErrorHandler.java
@@ -2,6 +2,8 @@ package com.inventoMate.configuration;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -45,4 +47,16 @@ public class GlobalErrorHandler {
 	public ErrorMessage handleInternalError(final HttpServletRequest request, final Exception error) {
 		return ErrorMessage.from(error.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR.value());
 	}
+	
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ErrorMessage handleValidationExceptions(MethodArgumentNotValidException ex) {
+        StringBuilder errorMessage = new StringBuilder("Error de validación: ");
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessageText = error.getDefaultMessage();
+            errorMessage.append(fieldName).append(" ").append(errorMessageText).append("; ");
+        });
+        return ErrorMessage.from(errorMessage.toString(), HttpStatus.BAD_REQUEST.value());
+    }
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/configuration/GlobalErrorHandler.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/configuration/GlobalErrorHandler.java
@@ -19,30 +19,30 @@ public class GlobalErrorHandler {
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	@ExceptionHandler(NoHandlerFoundException.class)
 	public ErrorMessage handleNotFound(final HttpServletRequest request, final Exception error) {
-		return ErrorMessage.from("Not Found");
+		return ErrorMessage.from("Not Found",HttpStatus.NOT_FOUND.value());
 	}
 
 	@ResponseStatus(HttpStatus.FORBIDDEN)
 	@ExceptionHandler(AccessDeniedException.class)
 	public ErrorMessage handleAccessDenied(final HttpServletRequest request, final Exception error) {
-		return ErrorMessage.from("Permission denied");
+		return ErrorMessage.from("Permission denied",HttpStatus.FORBIDDEN.value());
 	}
 	
     @ResponseStatus(HttpStatus.CONFLICT)
     @ExceptionHandler(ResourceAlreadyExistsException.class)
     public ErrorMessage handleResourceAlreadyExists(final HttpServletRequest request, final Exception error) {
-        return ErrorMessage.from(error.getMessage());
+        return ErrorMessage.from(error.getMessage(),HttpStatus.CONFLICT.value());
     }
     
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(ResourceNotFoundException.class)
     public ErrorMessage handleResourceNotFound(final HttpServletRequest request, final Exception error) {
-        return ErrorMessage.from(error.getMessage());
+        return ErrorMessage.from(error.getMessage(),HttpStatus.NOT_FOUND.value());
     }
     
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ExceptionHandler(Throwable.class)
 	public ErrorMessage handleInternalError(final HttpServletRequest request, final Exception error) {
-		return ErrorMessage.from(error.getMessage());
+		return ErrorMessage.from(error.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR.value());
 	}
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/configuration/security/AuthenticationErrorHandler.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/configuration/security/AuthenticationErrorHandler.java
@@ -25,7 +25,7 @@ public class AuthenticationErrorHandler implements AuthenticationEntryPoint {
 	@Override
 	public void commence(final HttpServletRequest request, final HttpServletResponse response,
 			final AuthenticationException authException) throws IOException, ServletException {
-		final var errorMessage = ErrorMessage.from("Requires authentication");
+		final var errorMessage = ErrorMessage.from("Requires authentication",HttpStatus.UNAUTHORIZED.value());
 		final var json = mapper.writeValueAsString(errorMessage);
 
 		response.setStatus(HttpStatus.UNAUTHORIZED.value());

--- a/backend/backend_spring/src/main/java/com/inventoMate/configuration/security/SecurityConfig.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/configuration/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
 						.requestMatchers(HttpMethod.PUT, "/api/roles/**").hasAuthority("assign:roles-to-user")
 						// users
 						.requestMatchers("/api/users/create").hasAuthority("create:user")
-						.requestMatchers("/api/users/me").authenticated()
+						.requestMatchers("/api/users/**").authenticated()
 						// empresas
 						.requestMatchers("/api/empresas/me").hasAuthority("read:company-owner")
 						.requestMatchers("/api/empresas/create").authenticated()

--- a/backend/backend_spring/src/main/java/com/inventoMate/controllers/RoleController.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/controllers/RoleController.java
@@ -17,7 +17,6 @@ import com.inventoMate.dtos.roles.RolToUserDTO;
 import com.inventoMate.dtos.roles.RoleDTO;
 import com.inventoMate.dtos.roles.RolePermissionsDTO;
 import com.inventoMate.services.RoleAuth0Service;
-import com.inventoMate.services.impl.RoleAuth0ServiceImpl;
 
 import lombok.AllArgsConstructor;
 

--- a/backend/backend_spring/src/main/java/com/inventoMate/controllers/UserController.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/controllers/UserController.java
@@ -5,25 +5,30 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import com.auth0.exception.Auth0Exception;
 import com.inventoMate.dtos.users.CreateUserWithRolDTO;
 import com.inventoMate.dtos.users.UsuarioDTO;
+import com.inventoMate.payload.ApiResponse;
+import com.inventoMate.payload.EditUserRequest;
 import com.inventoMate.services.UserAuth0Service;
 import com.inventoMate.services.UsuarioService;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @RestController
 @AllArgsConstructor
 @RequestMapping("api/users")
-@Validated
 @CrossOrigin("*")
+@Validated
 public class UserController {
 
 	private final UserAuth0Service userService;
@@ -43,7 +48,27 @@ public class UserController {
 	@GetMapping("/me")
 	public ResponseEntity<UsuarioDTO> getProfile(@AuthenticationPrincipal Jwt jwt) throws Auth0Exception {
 		var id = jwt.getSubject();
-		return ResponseEntity.ok(usuarioService.getUserByIdAuth0(id));
+		return ResponseEntity.ok(usuarioService.getProfileCurrentUser(id));
+	}
+	
+	@PutMapping("/edit")
+	public ResponseEntity<UsuarioDTO> editUserPrincipal(@AuthenticationPrincipal Jwt jwt, @RequestBody @Valid EditUserRequest usuario) throws Auth0Exception {
+		var id = jwt.getSubject();
+		return ResponseEntity.ok(usuarioService.updateUser(id,usuario));
+	}
+	
+	@GetMapping("/edit/password")
+	public ResponseEntity<?>  editPasswordUserPrincipal(@AuthenticationPrincipal Jwt jwt) throws Auth0Exception {
+		var id = jwt.getSubject();
+		return ResponseEntity.ok(userService.editPasswordRequest(id));
+	}
+	
+	@DeleteMapping("/delete")
+	public ResponseEntity<?>  deleteUserPrincipal(@AuthenticationPrincipal Jwt jwt) throws Auth0Exception {
+		var id = jwt.getSubject();
+		usuarioService.deleteUserPrincipal(id);
+		userService.deleteUserByAuth0Id(id,jwt.getTokenValue());
+		return ResponseEntity.ok().body(new ApiResponse(true, "User deleted successfully"));
 	}
 
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/dtos/empresas/EmpresaDTO.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/dtos/empresas/EmpresaDTO.java
@@ -1,13 +1,7 @@
 package com.inventoMate.dtos.empresas;
 
-import java.util.List;
-
-import com.inventoMate.dtos.sucursales.SucursalDTO;
 import com.inventoMate.dtos.users.OwnerDTO;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Null;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,22 +11,14 @@ import lombok.NoArgsConstructor;
 @Data
 public class EmpresaDTO {
 
-	@Null
 	private Long idEmpresa;
 	
-	@NotBlank
-	@Size(min = 3, message = "el nombre debe contener al menos 3 caracteres")
 	private String nombreEmpresa;
 
-	@Size(max = 25, message = "la descripcion no debe ser mayor a 25 caracteres")
 	private String descripcion;
 
 	private String logo;
 	
-	@Null
-	private List<SucursalDTO> sucursales;
-	
-	@Null
     private OwnerDTO owner;
 	
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/dtos/users/OwnerDTO.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/dtos/users/OwnerDTO.java
@@ -11,8 +11,6 @@ public class OwnerDTO {
 	
     private Long idUsuario;
 
-    private String idAuth0;
-
     private String nickname;
 
     private String email;

--- a/backend/backend_spring/src/main/java/com/inventoMate/dtos/users/UsuarioDTO.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/dtos/users/UsuarioDTO.java
@@ -2,37 +2,32 @@ package com.inventoMate.dtos.users;
 
 import java.util.List;
 
+import com.inventoMate.dtos.empresas.EmpresaDTO;
 import com.inventoMate.dtos.roles.RolDTO;
 import com.inventoMate.dtos.sucursales.SucursalDTO;
-
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Null;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class UsuarioDTO {
 
     private Long idUsuario;
 
-    @NotNull
-    private String idAuth0;
-
     private String nickname;
 
-    @NotBlank
-    @Email
+    private String picture;
+    
     private String email;
 	
-    @Null
+    private EmpresaDTO empresa; 
+    
     private SucursalDTO sucursal;
     
-    @Null
     private List<RolDTO> roles;
 
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/entities/Usuario.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/entities/Usuario.java
@@ -39,6 +39,9 @@ public class Usuario {
 	@Column(name = "email", nullable = false)
 	private String email;
 
+	@Column(nullable = true)
+	private String picture;
+	
 	@ManyToOne
 	@JoinColumn(name = "id_sucursal", nullable = true)
 	private Sucursal sucursal;

--- a/backend/backend_spring/src/main/java/com/inventoMate/models/ErrorMessage.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/models/ErrorMessage.java
@@ -5,9 +5,11 @@ import lombok.Value;
 @Value
 public class ErrorMessage {
 
+	
+	private int statusCode;
 	private String message;
 
-	public static ErrorMessage from(final String message) {
-		return new ErrorMessage(message);
+	public static ErrorMessage from(final String message, final int statusCode) {
+		return new ErrorMessage(statusCode,message);
 	}
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/payload/ApiResponse.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/payload/ApiResponse.java
@@ -1,0 +1,13 @@
+package com.inventoMate.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ApiResponse {
+
+    private Boolean success;
+    private String message;
+	
+}

--- a/backend/backend_spring/src/main/java/com/inventoMate/payload/EditUserRequest.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/payload/EditUserRequest.java
@@ -1,0 +1,24 @@
+package com.inventoMate.payload;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class EditUserRequest {
+
+    @Size(min = 4, max = 25, message = "El apodo debe tener entre 4 y 25 caracteres")
+    @Pattern(regexp = "^(?!(?:.*\\s){3})[a-zA-Z\\s]+", message = "El apodo solo puede contener letras y hasta 2 espacios")
+    private String nickname;
+    
+    private String picture;
+    
+    @Email(message = "Debe ser una dirección de correo electrónico válida")
+    private String email;
+    
+}

--- a/backend/backend_spring/src/main/java/com/inventoMate/repositories/EmpresaRepository.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/repositories/EmpresaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.inventoMate.entities.Empresa;
+import com.inventoMate.entities.Sucursal;
 import com.inventoMate.entities.Usuario;
 
 @Repository
@@ -14,5 +15,7 @@ public interface EmpresaRepository extends JpaRepository<Empresa, Long> {
 	boolean existsByOwner(Usuario owner);
 
 	Optional<Empresa> findByOwner(Usuario owner);
+	
+	Optional<Empresa> findBySucursalesContains(Sucursal sucursal);
 	
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/repositories/SucursalRepository.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/repositories/SucursalRepository.java
@@ -1,0 +1,16 @@
+package com.inventoMate.repositories;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.inventoMate.entities.Sucursal;
+import com.inventoMate.entities.Usuario;
+
+public interface SucursalRepository extends JpaRepository<Sucursal, Long> {
+
+	boolean existsByUsuariosContains(Usuario usuario);
+
+	Optional<Sucursal> findByUsuariosContains(Usuario usuario);
+	
+}

--- a/backend/backend_spring/src/main/java/com/inventoMate/repositories/UsuarioRepository.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/repositories/UsuarioRepository.java
@@ -11,5 +11,7 @@ public interface UsuarioRepository extends JpaRepository<Usuario,Long>{
 	boolean existsByIdAuth0(String idAuth0);
 
 	Optional<Usuario> findByIdAuth0(String idAuth0);
+
+	void deleteByIdAuth0(String idAuth0);
 	
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/services/UserAuth0Service.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/services/UserAuth0Service.java
@@ -2,11 +2,20 @@ package com.inventoMate.services;
 
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.mgmt.users.User;
+import com.inventoMate.payload.EditUserRequest;
+
+import jakarta.validation.Valid;
 
 public interface UserAuth0Service {
 
-	Object createUserWithRole(String email, String roleId, String password) throws Auth0Exception;
+	User createUserWithRole(String email, String roleId, String password) throws Auth0Exception;
 
 	User getUserById(String subject) throws Auth0Exception;
 
+	void updateUser(String id, @Valid EditUserRequest usuarioEditRequest) throws Auth0Exception;
+
+	Object editPasswordRequest(String id) throws Auth0Exception;
+
+	void deleteUserByAuth0Id(String id, String token) throws Auth0Exception;
+	
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/services/UsuarioService.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/services/UsuarioService.java
@@ -3,11 +3,17 @@ package com.inventoMate.services;
 
 import com.auth0.exception.Auth0Exception;
 import com.inventoMate.dtos.users.UsuarioDTO;
+import com.inventoMate.payload.EditUserRequest;
+
+import jakarta.validation.Valid;
 
 public interface UsuarioService {
 
-	UsuarioDTO createUsuario(String id) throws Auth0Exception;
+	UsuarioDTO createUsuario(String idAuth0) throws Auth0Exception;
 
-	UsuarioDTO getUserByIdAuth0(String idAuth0) throws Auth0Exception;
+	UsuarioDTO getProfileCurrentUser(String idAuth0) throws Auth0Exception;
 
+	UsuarioDTO updateUser(String idAuth0,  @Valid EditUserRequest usuario) throws Auth0Exception;
+
+	void deleteUserPrincipal(String idAuth0);
 }

--- a/backend/backend_spring/src/main/java/com/inventoMate/services/impl/UsuarioServiceImpl.java
+++ b/backend/backend_spring/src/main/java/com/inventoMate/services/impl/UsuarioServiceImpl.java
@@ -1,19 +1,30 @@
 package com.inventoMate.services.impl;
 
+import java.util.stream.Collectors;
+
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
-
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.auth0.exception.Auth0Exception;
 import com.auth0.json.mgmt.users.User;
+import com.inventoMate.dtos.empresas.EmpresaDTO;
+import com.inventoMate.dtos.roles.RolDTO;
+import com.inventoMate.dtos.sucursales.SucursalDTO;
 import com.inventoMate.dtos.users.UsuarioDTO;
+import com.inventoMate.entities.Empresa;
+import com.inventoMate.entities.Sucursal;
 import com.inventoMate.entities.Usuario;
 import com.inventoMate.exceptions.ResourceAlreadyExistsException;
 import com.inventoMate.exceptions.ResourceNotFoundException;
+import com.inventoMate.payload.EditUserRequest;
+import com.inventoMate.repositories.EmpresaRepository;
+import com.inventoMate.repositories.SucursalRepository;
 import com.inventoMate.repositories.UsuarioRepository;
 import com.inventoMate.services.UserAuth0Service;
 import com.inventoMate.services.UsuarioService;
 
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(onConstructor = @__(@Autowired))
@@ -21,13 +32,16 @@ import lombok.AllArgsConstructor;
 public class UsuarioServiceImpl implements UsuarioService {
 
 	private final UsuarioRepository usuarioRepository;
+	private final EmpresaRepository empresaRepository;
 	private final UserAuth0Service userAuthService;
+	private final SucursalRepository sucursalRepository;
 	private final ModelMapper modelMapper;
 	
 	public UsuarioDTO createUsuario(String idAuth0) throws Auth0Exception {
 		
 		// obtengo el usuario de auth0 por su Id
 		User userAuth0 = userAuthService.getUserById(idAuth0);
+		
 		
 		// valido que no exista un usuario ya creado
 		if(usuarioRepository.existsByIdAuth0(idAuth0)) {
@@ -40,6 +54,7 @@ public class UsuarioServiceImpl implements UsuarioService {
 		usuario.setEmail(userAuth0.getEmail());
 		usuario.setIdAuth0(userAuth0.getId());
 		usuario.setNickname(userAuth0.getNickname());
+		usuario.setPicture(userAuth0.getPicture());
 		
 		// lo guardo en la bd
 		usuarioRepository.save(usuario);
@@ -49,12 +64,65 @@ public class UsuarioServiceImpl implements UsuarioService {
 	}
 
 	@Override
-	public UsuarioDTO getUserByIdAuth0(String idAuth0) throws Auth0Exception {
+	public UsuarioDTO getProfileCurrentUser(String idAuth0) throws Auth0Exception {
 		
-		Usuario usuario  = usuarioRepository.findByIdAuth0(idAuth0).orElseThrow(()-> 
+		// recupero usuario principal
+		Usuario usuario  = userByAuth0Id(idAuth0);
+		// recupero empresa si es dueño
+		Empresa empresa = null;
+		if(empresaRepository.existsByOwner(usuario))
+			empresaRepository.findByOwner(usuario).orElse(null);
+		// recupero sucursal si es empleado
+		Sucursal sucursal = null;
+		if(sucursalRepository.existsByUsuariosContains(usuario))
+			sucursal = sucursalRepository.findByUsuariosContains(usuario).orElse(null);
+		// recupero empresa para la que trabaja si es empleado
+		if(sucursal != null)
+			empresa = empresaRepository.findBySucursalesContains(sucursal).orElse(null);
+		// mapeo entidades a dtos
+		EmpresaDTO empresaResponse= empresa != null? modelMapper.map(empresa, EmpresaDTO.class) : null;
+		SucursalDTO sucursalResponse= sucursal != null? modelMapper.map(sucursal, SucursalDTO.class) : null;
+		UsuarioDTO usuarioProfile = UsuarioDTO.builder().email(usuario.getEmail())
+				.empresa(empresaResponse)
+				.sucursal(sucursalResponse)
+				.idUsuario(usuario.getIdUsuario())
+				.nickname(usuario.getNickname())
+				.picture(usuario.getPicture())
+				.roles(usuario.getRoles().stream()
+						.map(rol -> modelMapper
+								.map(rol, RolDTO.class))
+						.collect(Collectors.toList()))
+				.build();
+		
+		return usuarioProfile;
+	}
+
+	@Override
+	public UsuarioDTO updateUser(String id, @Valid EditUserRequest usuarioEditRequest) throws Auth0Exception{
+		
+		// obtengo usuario por auth0 id
+		Usuario usuario = userByAuth0Id(id);
+		
+		//actualizo campos en BD local
+		if(usuarioEditRequest.getEmail() != null) usuario.setEmail(usuarioEditRequest.getEmail());
+		usuario.setNickname(usuarioEditRequest.getNickname());
+		usuario.setPicture(usuarioEditRequest.getPicture());
+		usuarioRepository.save(usuario);			
+		//actualizo campos en BD auth0
+		userAuthService.updateUser(id, usuarioEditRequest);
+		
+		return getProfileCurrentUser(id);
+	}
+	
+	private Usuario userByAuth0Id(String idAuth0) {
+		return usuarioRepository.findByIdAuth0(idAuth0).orElseThrow(()-> 
 			new ResourceNotFoundException("Usuario", "id_auth0", idAuth0)
 		);
-		
-		return modelMapper.map(usuario, UsuarioDTO.class);
+	}
+
+	@Override
+	@Transactional
+	public void deleteUserPrincipal(String idAuth0){
+		usuarioRepository.deleteByIdAuth0(idAuth0);
 	}
 }

--- a/backend/backend_spring/src/main/resources/application.properties
+++ b/backend/backend_spring/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 # Spring
 spring.application.name=backend_spring
-#spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 spring.web.resources.add-mappings=false
 logging.level.org.springframework.web = DEBUG
 # Server
@@ -15,9 +14,9 @@ auth0.domain=${AUTH0_DOMAIN}
 auth0.client-id=${AUTH0_CLIENT_ID}
 auth0.client-secret=${AUTH0_CLIENT_SECRET}
 #Conexion API Restful conb mySql
-#spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.sql.init.platform=mysql
-spring.datasource.url=jdbc:mysql://localhost:3306/db-inventomate?useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://localhost:3306/bd-inventomate?useSSL=false&allowPublicKeyRetrieval=true
 spring.datasource.username=${USER_DATABASE}
 spring.datasource.password=${PASSWORD_DATABASE}
 spring.jpa.show-sql=true

--- a/backend/backend_spring/src/test/java/com/inventoMate/TestCreateEmpresa.java
+++ b/backend/backend_spring/src/test/java/com/inventoMate/TestCreateEmpresa.java
@@ -1,38 +1,28 @@
 package com.inventoMate;
 
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
 import com.auth0.exception.Auth0Exception;
-import com.inventoMate.*;
 import com.inventoMate.dtos.empresas.EmpresaDTO;
 import com.inventoMate.dtos.users.OwnerDTO;
-import com.inventoMate.dtos.users.UsuarioDTO;
-import com.inventoMate.entities.Empresa;
-import com.inventoMate.entities.Usuario;
+
 import com.inventoMate.repositories.EmpresaRepository;
 import com.inventoMate.repositories.UsuarioRepository;
 import com.inventoMate.services.EmpresaService;
 import com.inventoMate.services.UsuarioService;
 import com.inventoMate.services.impl.EmpresaServiceImpl;
-import com.inventoMate.services.impl.UsuarioServiceImpl;
-
-import static org.hamcrest.CoreMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
-public class testCreateEmpresa {
+public class TestCreateEmpresa {
 	
   	@Mock
     private EmpresaService empresaServiceMock;
@@ -57,7 +47,6 @@ public class testCreateEmpresa {
         empresaDTO.setDescripcion("Descripción de prueba");
         empresaDTO.setLogo("logo.png");
         OwnerDTO ownerDTO = new OwnerDTO();
-        ownerDTO.setIdAuth0(idAuth0);
         empresaDTO.setOwner(ownerDTO);
 
         // Comportamiento esperado del mock

--- a/backend/backend_spring/src/test/java/com/inventoMate/TestUsuarioService.java
+++ b/backend/backend_spring/src/test/java/com/inventoMate/TestUsuarioService.java
@@ -14,15 +14,13 @@ import com.inventoMate.services.impl.UsuarioServiceImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
 @ExtendWith(MockitoExtension.class)
-public class testUsuarioService {
+public class TestUsuarioService {
 
     @Mock
     private UsuarioRepository usuarioRepositoryMock;
@@ -55,7 +53,6 @@ public class testUsuarioService {
 
         // Configurar el comportamiento esperado del mock de ModelMapper
         UsuarioDTO usuarioDTOMock = new UsuarioDTO();
-        usuarioDTOMock.setIdAuth0(idAuth0);
         usuarioDTOMock.setEmail("test@example.com");
         usuarioDTOMock.setNickname("test_user");
         when(modelMapperMock.map(any(Usuario.class), eq(UsuarioDTO.class))).thenReturn(usuarioDTOMock);
@@ -65,7 +62,6 @@ public class testUsuarioService {
 
         // Verificación
         Assertions.assertNotNull(usuarioCreado);
-        Assertions.assertEquals(idAuth0, usuarioCreado.getIdAuth0());
         Assertions.assertEquals("test@example.com", usuarioCreado.getEmail());
         Assertions.assertEquals("test_user", usuarioCreado.getNickname());
     }


### PR DESCRIPTION
## CRUD de current users

### endpoints

1. Guardar usuario de auth0 en BD local
   - `curl --location --request POST 'http://localhost:8080/api/users/sign-up'`
2. Ver perfil del usuario actual
   - `curl --location 'http://localhost:8080/api/users/me'`
3. Editar usuario actual (en bd local y auth0 db)
   - `curl --location --request PUT 'http://localhost:8080/api/users/edit'`
   - no se puede editar email si se logueo utilizando google (oauth2 provider), en ese caso dejar el campo nulo.
4. Solicitud de cambio de contraseña
   - `curl --location 'http://localhost:8080/api/users/edit/password'`
   - no se puede solicitar el cambio de contraseña si se logueo utilizando google (oauth02 provider)
   - devuelve un ticket (link) para cambiarla.
 5. Eliminar usuario actual
    - `curl --location --request DELETE 'http://localhost:8080/api/users/delete'`
   
 Todos necesitan estar autenticados, y todos solicitan el token de auth0 en el header.
 En postman están todos los ejemplos y la documentacion de estos endpoints.

